### PR TITLE
Update Regression_tuner.ipynb

### DIFF
--- a/class/Fundamentals/Regression_tuner.ipynb
+++ b/class/Fundamentals/Regression_tuner.ipynb
@@ -374,7 +374,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import kerastuner as kt"
+    "import keras_tuner as kt"
    ]
   },
   {
@@ -426,6 +426,7 @@
     "                                            min_value=32,\n",
     "                                            max_value=128,\n",
     "                                            step=32),\n",
+    "                               input_shape(7,),\n",
     "                               activation='relu'))\n",
     "    #\u00a0Sample different activation functions with hp.Choice \n",
     "    model.add(layers.Dense(1, activation=hp.Choice('output_activation', ['relu', 'linear'])))\n",


### PR DESCRIPTION
Changes have been made to the build_model function, adding the input layer definition to the sequential model with input_shape. Additionally, the kerastuner library has been updated as keras_tuner, as it is obsolete.